### PR TITLE
feat: add @this

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"displayName": "JavaScript Comment Snippet",
 	"description": "Comment snippets for JavaScript",
 	"icon": "art/icon.png",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"galleryBanner": {
 		"color": "#ffffff",
 		"theme": "dark"

--- a/src/function.json
+++ b/src/function.json
@@ -22,5 +22,10 @@
 		"prefix": ["@requires"],
 		"body": ["@requires ${1:module}"],
 		"description": "syntax: `@requires <someModuleName>`;\nThis file requires a JavaScript module.\nhttps://jsdoc.app/tags-requires.html\n"
+	},
+  "@this": {
+		"prefix": ["@this"],
+		"body": ["@this ${1:{${2:TYPE}\\} }${3:description}"],
+		"description": "syntax: `@this <type> [description]`;\nUsed to indicate what the this keyword refers to when used within another symbol.\nhttps://jsdoc.app/tags-this.html\n"
 	}
 }


### PR DESCRIPTION

This PR will add `@this` [jsdoc](https://jsdoc.app/tags-this.html) to snippet collections.

`@this` is handy in some situations when we want to define the global reference type (indicates what the `this` keyword refers to).

There was no docs in [esdoc](https://esdoc.org/) or [tsdoc](https://tsdoc.org/) about `@this` so I only included [jsdoc](https://jsdoc.app/tags-this.html) reference.